### PR TITLE
Fix for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-NAME=timereport_backend
+NAME=timereport-api
 VERSION=0.0.1
 
-WORKDIR = timereport_backend
-PORT = 8010
+DB_PORT = 8000
+API_PORT = 8010
+
+export DB_HOST = http://localhost:$(DB_PORT)
 
 .PHONY: pull run stop restart rm
 
@@ -10,8 +12,10 @@ pull:
 	docker pull amazon/dynamodb-local
 
 run:
-	docker run --name dynamodb-local -d -p $(PORT):$(PORT) amazon/dynamodb-local
-	cd $(WORKDIR) && chalice local
+	docker run --rm --name dynamodb-local -d -p $(DB_PORT):$(DB_PORT) amazon/dynamodb-local
+	echo "Wait for local DB to start..."
+	sleep 5
+	chalice local --port $(API_PORT)
 
 stop:
 	docker stop dynamodb-local
@@ -19,8 +23,6 @@ stop:
 restart:
 	docker restart dynamodb-local
 
-rm:
-	docker rm dynamodb-local
 
 default: run
-clean: stop rm
+clean: stop

--- a/Readme.md
+++ b/Readme.md
@@ -1,42 +1,48 @@
-#### timereport_backend
+# timereport-api
+An API for timereport
 
-##### Requirements
+## Architecture
+* AWS API Gateway
+* AWS lambda
+* AWS dynamodb
 
-###### development
-- Docker (to run amazon/dynamodb-local)
-- chalice local
+## Setup
 
-###### production
 - aws credentials for dynamodb access
 - aws credentials for travis-ci
 - edit .chalice/config.json env variables
 
-##### Instructions
 
-- make run
+## Local development
 
+### prerequisite
+- Docker (to run amazon/dynamodb-local)
+- packages in requirements.txt
+
+To start a local dynamodb and chalice:
 ```
-Will pull and run amazon/dynamodb-local from docker on port 8000
-Make sure to run chalice as well.
-
-#
-# In Production:
-#
-Point os.environ['DB_URL'] to your production amazonaws database. 
-#
-DB_URL = http://dynamodb.eu-north-1.amazonaws.com
-DB_REGION = 'eu-north-1'
-#
-#
-or configure ~/.aws/credentials file with content:
-#
-[default]
-aws_access_key_id = myAccessKey
-aws_secret_access_key = mySecretAccessKey
-#
-#
-
-
-Chalice will create data in backend (dynamodb) as well as fetch data from it.
-
+make run
 ```
+Now you should be able to try the API on http://localhost:8010
+
+To stop and cleanup:
+```
+make clean
+```
+
+## Deployment
+Deployment to dev and prod is done automatically
+
+### DEV
+To deploy to dev, open A pull request and it will automtically deploy
+
+### PRODUCTION
+to deploy to prod, push/merge to master.
+
+### Manually
+__note__: This requires that you have setup the credentials for AWS
+
+### DEV
+`chalice deploy --stage dev`
+### PROD
+`chalice deploy --stage prod`

--- a/chalicelib/model/Dynamo.py
+++ b/chalicelib/model/Dynamo.py
@@ -27,7 +27,8 @@ class DynamoBoto(EventModel.Meta):
     """
     region = EventModel.Meta.region
     table_name = EventModel.Meta.table_name
-    dynamodb = boto3.resource("dynamodb", region_name=region)
+    host = EventModel.Meta.host
+    dynamodb = boto3.resource("dynamodb", region_name=region, endpoint_url=host)
     table = dynamodb.Table(table_name)
 
 

--- a/chalicelib/model/Dynamo.py
+++ b/chalicelib/model/Dynamo.py
@@ -12,6 +12,7 @@ class EventModel(Model):
     """
     class Meta(object):
         table_name = os.getenv('DB_TABLE_NAME', 'dev_event')
+        host = os.getenv('DB_HOST', None)
         region = os.getenv('DB_REGION', 'eu-north-1')
 
     user_id = UnicodeAttribute(hash_key=True)


### PR DESCRIPTION
In order for local development setup to work we need to be able to set
the host URL.
This is now possible with `DB_HOST` env variable.

The Makefile has been updated to work with these changes.
Also the instructions in the readme has been updated.