### PR TITLE
Add deploying dev timereport-api via github action

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,32 @@
+name: Test & deploy dev
+
+on: [push]
+
+jobs:
+  dev:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    - name: Run Tests
+      run: |
+        make dynamo
+        sleep 5
+        make ci-server
+        sleep 5
+        pytest -v
+    - name: Deploy dev
+      run: chalice deploy --stage dev
+

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,6 +27,13 @@ jobs:
         make ci-server
         sleep 5
         pytest -v
+      env:
+        # pynamodb needs credentails to be set, even if they're not used in local mode 🤷‍♂️
+        AWS_ACCESS_KEY_ID: "fake ID"
+        AWS_SECRET_ACCESS_KEY: "fake secret"
     - name: Deploy dev
       run: chalice deploy --stage dev
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ notifications:
 stages:
   - name: Tests
     if: type = push
-  - name: Deploy to dev
-    if: type = push
   - name: Deploy to prod
     if: type = push AND branch = master
 
@@ -31,9 +29,6 @@ jobs:
         - make ci-server
         - sleep 5
         - pytest
-    - stage: Deploy to dev
-      script:
-      - chalice deploy --stage dev
     - stage: Deploy to prod
       on:
         branch: master


### PR DESCRIPTION
~~Create workflow for testing and deploying dev via github actions.
Remove deploying to dev via travis.

~~To get the organisation secrets apparently the workflow needs to be in master branch.~~
~~So this is why I start with getting deploying to dev to work first.~~

Update: Read it wrong. It was only for forks 😄 

#35 